### PR TITLE
Option to reuse existing resources in Terraform

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,15 @@ Here we will create the `terraform/terraform.tfvars` file and explain how to obt
     tz                           = "America/New_York"
     pihole_webpassword           = "<generate a strong password. Avoid these characters: '=' and ';'>"
     pihole_dns_ip                = "1.1.1.1"
+    
+    # Base/Shared resources (OPTIONAL)
+    oci_vcn_id              = "<ID of an already existing VCN in case you want to use it; otherwise, a new one will be created>"
+    oci_internet_gateway_id = "<ID of an already existing internet gateway in case you want to use it; otherwise, a new one will be created>"
+    oci_route_table_id      = "<ID of an already existing route table in case you want to use it; otherwise, a new one will be created>"
+    oci_security_list_id    = "<ID of an already existing security list in case you want to use it; otherwise, a new one will be created>"
+    oci_subnet_id           = "<ID of an already existing subnet in case you want to use it; otherwise, a new one will be created>"
+    oci_image_id            = "<ID of an already existing image in case you want to use it; otherwise, a new one will be created>"
+
     ```
 
     Parameters:

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,3 +1,27 @@
+output "local_oci_vcn_id" {
+  value = local.oci_vcn_id
+}
+
+output "local_oci_internet_gateway_id" {
+  value = local.oci_internet_gateway_id
+}
+
+output "local_oci_route_table_id" {
+  value = local.oci_route_table_id
+}
+
+output "local_oci_security_list_id" {
+  value = local.oci_security_list_id
+}
+
+output "local_oci_subnet_id" {
+  value = local.oci_subnet_id
+}
+
+output "local_oci_image_id" {
+  value = local.oci_image_id
+}
+
 output "availability_domains" {
   value = data.oci_identity_availability_domains.availability_domains.availability_domains[0]["name"]
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -28,6 +28,45 @@ variable "oci_private_key_base64" {
 
 # ----- resources -----
 
+# Base/Shared
+
+variable "oci_vcn_id" {
+  type      = string
+  sensitive = false
+  default   = null
+}
+
+variable "oci_internet_gateway_id" {
+  type      = string
+  sensitive = false
+  default   = null
+}
+
+variable "oci_route_table_id" {
+  type      = string
+  sensitive = false
+  default   = null
+}
+
+variable "oci_security_list_id" {
+  type      = string
+  sensitive = false
+  default   = null
+}
+
+variable "oci_subnet_id" {
+  type      = string
+  sensitive = false
+  default   = null
+}
+
+variable "oci_image_id" {
+  type      = string
+  sensitive = false
+  default   = null
+}
+
+
 # VCN
 
 variable "vcn_cidr_blocks" {
@@ -132,7 +171,7 @@ variable "instance_shape_config_memory_in_gbs" {
 variable "instance_shape_config_ocpus" {
   type      = number
   sensitive = false
-  default   = 2
+  default   = 1
 }
 
 variable "instance_source_details_boot_volume_size_in_gbs" {


### PR DESCRIPTION
Add option in Terraform to get, e.g., the VCN ID from a variable. Now, if the VCN ID variable is empty, the block to create a new VCN will run. This logic was added to the VCN, subnet, route table, internet gateway, and security list.