### PR TITLE
Create VNIC as a separate resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,11 +444,11 @@ Password: 6V5!B6J!2FxM*$PJ#KP*aEN^%
 
 - Save Pi-hole configuration in an object-storage service, like S3, to recover the settings if the instance has issues or needs maintenance. The server should access the object storage privately with a service gateway.
 - Run instance in an autoscaling group to recover from some problem with the hardware.
-- Use a static public IP.
 - Add more than one client to the WireGuard server.
 - Add budget or spending limit for OCI in case of unexpected charges.
 - Run process in the containers as non-root.
 - Add Cloudflare container for Pi-hole to use DNS over HTTPS.
+- Create a key to encrypt boot volume. kmsKeyId
 
 See the [open issues](https://github.com/OscarB7/pihole-terraform/issues) for a complete list of proposed features (and known issues).
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -45,3 +45,7 @@ output "port_pihole_web" {
 output "instance_public_ip" {
   value = oci_core_instance.pihole_wireguard.public_ip
 }
+
+output "reserved_public_ip" {
+  value = oci_core_public_ip.pihole_wireguard_vnic.ip_address
+}


### PR DESCRIPTION
Create VNIC as a separate resource to maintain the same public IP if the instance is recreated with "terraform apply"